### PR TITLE
Fix GNU compilation of the arm-cm/dpp_stm32f746g-discovery examples

### DIFF
--- a/examples/arm-cm/dpp_stm32f746g-discovery/qk/bsp.cpp
+++ b/examples/arm-cm/dpp_stm32f746g-discovery/qk/bsp.cpp
@@ -166,12 +166,12 @@ void USART1_IRQHandler(void) {
 // BSP functions =============================================================
 void BSP::init(void) {
     // NOTE:
-    // The global interrupt disable code prevents interrutps from firing
+    // The global interrupt disable code prevents interrupts from firing
     // prematurely until QF_onStartup(), when QF is fully initialized.
     // Unfortunately, the STM32Cube code that must be called from here,
-    // configures and starts interrutps (such as SysTick).
+    // configures and starts interrupts (such as SysTick).
     //
-    QF_PRIMASK_DISABLE(); // globally disable interrupts until QF::onStart()
+    QF_INT_DISABLE(); // globally disable interrupts until QF::onStart()
 
     RCC_OscInitTypeDef RCC_OscInitStruct;
     RCC_ClkInitTypeDef RCC_ClkInitStruct;

--- a/examples/arm-cm/dpp_stm32f746g-discovery/qv/bsp.cpp
+++ b/examples/arm-cm/dpp_stm32f746g-discovery/qv/bsp.cpp
@@ -159,12 +159,12 @@ void USART1_IRQHandler(void) {
 // BSP functions =============================================================
 void BSP::init(void) {
     // NOTE:
-    // The global interrupt disable code prevents interrutps from firing
+    // The global interrupt disable code prevents interrupts from firing
     // prematurely until QF_onStartup(), when QF is fully initialized.
     // Unfortunately, the STM32Cube code that must be called from here,
-    // configures and starts interrutps (such as SysTick).
+    // configures and starts interrupts (such as SysTick).
     //
-    QF_PRIMASK_DISABLE(); // globally disable interrupts until QF::onStart()
+    QF_INT_DISABLE(); // globally disable interrupts until QF::onStart()
 
     RCC_OscInitTypeDef RCC_OscInitStruct;
     RCC_ClkInitTypeDef RCC_ClkInitStruct;

--- a/examples/arm-cm/dpp_stm32f746g-discovery/qxk/bsp.cpp
+++ b/examples/arm-cm/dpp_stm32f746g-discovery/qxk/bsp.cpp
@@ -166,12 +166,12 @@ void USART1_IRQHandler(void) {
 // BSP functions =============================================================
 void BSP::init(void) {
     // NOTE:
-    // The global interrupt disable code prevents interrutps from firing
+    // The global interrupt disable code prevents interrupts from firing
     // prematurely until QF_onStartup(), when QF is fully initialized.
     // Unfortunately, the STM32Cube code that must be called from here,
-    // configures and starts interrutps (such as SysTick).
+    // configures and starts interrupts (such as SysTick).
     //
-    QF_PRIMASK_DISABLE(); // globally disable interrupts until QF::onStart()
+    QF_INT_DISABLE(); // globally disable interrupts until QF::onStart()
 
     RCC_OscInitTypeDef RCC_OscInitStruct;
     RCC_ClkInitTypeDef RCC_ClkInitStruct;
@@ -343,7 +343,7 @@ void QF::onStartup(void) {
     NVIC_EnableIRQ(USART1_IRQn); // UART1 interrupt used for QS-RX
 #endif
 
-    QF_PRIMASK_ENABLE(); // ready to accept interrupts
+    QF_INT_ENABLE(); // ready to accept interrupts
 }
 //............................................................................
 void QF::onCleanup(void) {


### PR DESCRIPTION
The  `arm-cm/dpp_stm32f746g-discovery/*/gnu` examples had references to QF_PRIMASK_DISABLE and QF_PRIMASK_ENABLE that weren't defined in the GNU `qf_port.h`.

This PR changes those calls to QF_INT_DISABLE/QF_INT_ENABLE to allow compilation with the GNU toolchain.