### PR TITLE
Added ucos-iii port with an Arduino example

### DIFF
--- a/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/ArduinoDue-qpcpp-ucos-iii.ino
+++ b/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/ArduinoDue-qpcpp-ucos-iii.ino
@@ -1,0 +1,60 @@
+/*
+ * Arduino Due Example to test the UCOS-III QPCPP Port
+ * To test this example UCOS-III port for arduino is needed
+ * https://github.com/vChavezB/uc-os3-arduino-due
+ * 
+ * 
+ */
+#include <uCOS-III_Due.h>
+
+#include "TimerTask.hpp"
+#include "ExampleAO.hpp"
+
+ExampleActiveObject exampleAO;
+TimerTask timer_task(&exampleAO);
+
+const unsigned long cpu_clock = 84000000; //Arduino Due Clock
+const int TimerTaskPrio = 1;
+
+
+void setup() {
+  Serial.begin(115200);
+  OS_ERR  err;
+  QS_INIT(0);
+  QP::QF::init();                               /* initialize the framework and UC OSIII */
+  CPU_Init();                                  /* Initialize uC/CPU services.                          */
+  OS_CPU_SysTickInitFreq(cpu_clock);            /* Init uC/OS periodic time src (SysTick).              */
+  err = timer_task.Create(TimerTaskPrio);
+  OS_ASSERT(err, OS_ERR_NONE);
+
+  static QP::QEvt const * exampleQueueSto[20];
+  static CPU_STK exampleStack[100];
+  OS_OPT task_opt = OS_OPT_TASK_STK_CLR | OS_OPT_TASK_STK_CHK;
+  exampleAO.setAttr(QP::TASK_NAME_ATTR, "Example AO"); //TODO add
+  exampleAO.setAttr(QP::TASK_OPT_ATTR, static_cast<void*>(&task_opt));
+  exampleAO.start(   TimerTaskPrio + 1,                // Less priority than the task that produces the signal
+                     &exampleQueueSto[0],        // storage for the AO's queue
+                     Q_DIM(exampleQueueSto), // queue's length [events]
+                     &exampleStack,          // stack storage
+                     sizeof(exampleStack),// stack size [bytes]
+                     (void *)0
+                 );
+  OSStart(&err);                                              /* Start multitasking (i.e. give control to uC/OS-III). */
+  OS_ASSERT(err, OS_ERR_NONE);
+  while (1U) ; /* Code should never enter here */
+}
+
+void loop() {
+  /* do nothing */
+}
+
+extern "C"  Q_NORETURN Q_onAssert(char const * const module, int location)
+{
+  Serial.print("Assert module:");
+  Serial.print(module);
+  Serial.print(" ");
+  Serial.println(location);
+  for (;;) {
+
+  }
+}

--- a/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/ExampleAO.cpp
+++ b/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/ExampleAO.cpp
@@ -1,0 +1,48 @@
+#include "ExampleAO.hpp"
+#include <Arduino.h>
+
+Q_STATE_DEF(ExampleActiveObject, Initial)
+{
+  Serial.println("initial state");
+  return tran(&State1);
+}
+
+Q_STATE_DEF(ExampleActiveObject, State1)
+{
+  QP::QState status_;
+  switch (e->sig)
+  {
+    case Q_ENTRY_SIG:
+      Serial.println("entry state1");
+      status_ = Q_RET_HANDLED;
+      break;
+    case SIG_TIMER:
+      Serial.println("Transition to State 2");
+      status_ = tran(&State2);
+      break;
+    default:
+      status_ = super(&top);
+      break;
+  }
+  return status_;
+}
+
+Q_STATE_DEF(ExampleActiveObject, State2)
+{
+  QP::QState status_;
+  switch (e->sig)
+  {
+    case Q_ENTRY_SIG:
+      Serial.println("entry state2");
+      status_ = Q_RET_HANDLED;
+      break;
+    case SIG_TIMER:
+      Serial.println("Transition State 1");
+      status_ = tran(&State1);
+      break;
+    default:
+      status_ = super(&top);
+      break;
+  }
+  return status_;
+}

--- a/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/ExampleAO.hpp
+++ b/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/ExampleAO.hpp
@@ -1,0 +1,22 @@
+#ifndef EXAMPLE_AO_HPP
+#define EXAMPLE_AO_HPP
+
+#include "qpcpp.hpp"  // QP-C++ framework
+
+enum Signals
+{
+  SIG_TIMER = QP::Q_USER_SIG,
+};
+
+class ExampleActiveObject: public QP::QActive
+{
+  public:
+    ExampleActiveObject(): QActive(Q_STATE_CAST(Initial)){}
+  private:
+    Q_STATE_DECL(Initial);
+    Q_STATE_DECL(State1);
+    Q_STATE_DECL(State2);
+
+};
+
+#endif

--- a/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/TimerTask.cpp
+++ b/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/TimerTask.cpp
@@ -1,0 +1,64 @@
+#include "TimerTask.hpp"
+#include "ExampleAO.hpp"
+#include <Arduino.h>
+
+int TimerTask::totalTasks = 0;
+
+const QP::QEvt TimerEvt = {.sig = SIG_TIMER, .poolId_ = 0, .refCtr_ = 0};
+
+TimerTask::TimerTask(QP::QActive * _act): act(_act)
+{
+
+}
+
+OS_ERR TimerTask::Create(OS_PRIO priority)
+{
+  OS_ERR err;
+  if (created == false)
+  {
+    created = false;
+    OSTaskCreate((OS_TCB     *) & (this->tcb),
+                 (CPU_CHAR   *)"TimerTask",
+                 (OS_TASK_PTR )this->Task,
+                 (void       *)this,
+                 (OS_PRIO     )priority,
+                 (CPU_STK    *) & (this->stack[0]),
+                 (CPU_STK_SIZE)stack_size / 10,
+                 (CPU_STK_SIZE)stack_size,
+                 (OS_MSG_QTY  )5,
+                 (OS_TICK     )10,
+                 (void       *)0,
+                 (OS_OPT      )(OS_OPT_TASK_STK_CLR | OS_OPT_TASK_STK_CHK),
+                 (OS_ERR     *)&err);
+    if (err == OS_ERR_NONE)
+    {
+      task_no = totalTasks++;
+    }
+  }
+  return err;
+}
+
+void  TimerTask::Task(void *p_arg)
+{
+  TimerTask * pTimerTask = (TimerTask * )p_arg;
+  OS_ERR      err;
+  int count = 0;
+  int task_no = pTimerTask->task_no;
+  Serial.print("Timer Task ");
+  Serial.print(task_no);
+  Serial.println(" started");
+  while (1)
+  {
+    Serial.print("Timer Task ");
+    Serial.print(task_no);
+    Serial.print(" execution #");
+    Serial.println(count++);
+    pTimerTask->act->POST(&TimerEvt, pTimerTask);
+    OSTimeDlyHMSM((CPU_INT16U) 0,
+                  (CPU_INT16U) 0,
+                  (CPU_INT16U) 1,   //Seconds
+                  (CPU_INT32U)500, //Milliseconds
+                  (OS_OPT )OS_OPT_TIME_DLY,
+                  (OS_ERR *)&err);
+  }
+}

--- a/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/TimerTask.hpp
+++ b/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/TimerTask.hpp
@@ -1,0 +1,29 @@
+#ifndef TIMERTASK_HPP
+#define TIMERTASK_HPP
+
+#include <uCOS-III_Due.h>
+#include "qpcpp.hpp"  // QP-C++ framework
+
+
+/*
+  Example class that holds a UCOS3
+  task which generates a signal after an
+  OS Delay and posts the event to an active object
+*/
+class TimerTask
+{
+  public:
+    TimerTask(QP::QActive * _act);
+    OS_ERR Create(OS_PRIO priority);
+  private:
+    static constexpr int stack_size = 256;
+    QP::QActive * act;
+    CPU_STK  stack[256];
+    OS_TCB  tcb;
+    int task_no;
+    static void  Task(void * args);
+    static int totalTasks;
+    bool created = false;
+};
+
+#endif

--- a/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/os_cfg/os_app_hooks.c
+++ b/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/os_cfg/os_app_hooks.c
@@ -1,0 +1,259 @@
+/*
+*********************************************************************************************************
+*                                              uC/OS-III
+*                                        The Real-Time Kernel
+*
+*                    Copyright 2009-2021 Silicon Laboratories Inc. www.silabs.com
+*
+*                                 SPDX-License-Identifier: APACHE-2.0
+*
+*               This software is subject to an open source license and is distributed by
+*                Silicon Laboratories Inc. pursuant to the terms of the Apache License,
+*                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
+*
+*********************************************************************************************************
+*/
+
+/*
+*********************************************************************************************************
+*
+*                                           APPLICATION HOOKS
+*
+* Filename : os_app_hooks.c
+* Version  : V3.08.01
+*********************************************************************************************************
+*/
+
+#define   MICRIUM_SOURCE
+#include "os_app_hooks.h"
+/*
+************************************************************************************************************************
+*                                              SET ALL APPLICATION HOOKS
+*
+* Description: Set ALL application hooks.
+*
+* Arguments  : none.
+*
+* Note(s)    : none
+************************************************************************************************************************
+*/
+
+void  App_OS_SetAllHooks (void)
+{
+#if OS_CFG_APP_HOOKS_EN > 0u
+    CPU_SR_ALLOC();
+
+
+    CPU_CRITICAL_ENTER();
+    OS_AppIdleTaskHookPtr   = App_OS_IdleTaskHook;
+
+#if (OS_CFG_TASK_STK_REDZONE_EN > 0u)
+    OS_AppRedzoneHitHookPtr = App_OS_RedzoneHitHook;
+#endif
+
+    OS_AppStatTaskHookPtr   = App_OS_StatTaskHook;
+
+    OS_AppTaskCreateHookPtr = App_OS_TaskCreateHook;
+
+    OS_AppTaskDelHookPtr    = App_OS_TaskDelHook;
+
+    OS_AppTaskReturnHookPtr = App_OS_TaskReturnHook;
+
+    OS_AppTaskSwHookPtr     = App_OS_TaskSwHook;
+
+    OS_AppTimeTickHookPtr   = App_OS_TimeTickHook;
+    CPU_CRITICAL_EXIT();
+#endif
+}
+
+
+/*
+************************************************************************************************************************
+*                                             CLEAR ALL APPLICATION HOOKS
+*
+* Description: Clear ALL application hooks.
+*
+* Arguments  : none.
+*
+* Note(s)    : none
+************************************************************************************************************************
+*/
+
+void  App_OS_ClrAllHooks (void)
+{
+#if OS_CFG_APP_HOOKS_EN > 0u
+    CPU_SR_ALLOC();
+
+
+    CPU_CRITICAL_ENTER();
+    OS_AppIdleTaskHookPtr   = (OS_APP_HOOK_VOID)0;
+
+#if (OS_CFG_TASK_STK_REDZONE_EN > 0u)
+    OS_AppRedzoneHitHookPtr = (OS_APP_HOOK_TCB)0;
+#endif
+
+    OS_AppStatTaskHookPtr   = (OS_APP_HOOK_VOID)0;
+
+    OS_AppTaskCreateHookPtr = (OS_APP_HOOK_TCB)0;
+
+    OS_AppTaskDelHookPtr    = (OS_APP_HOOK_TCB)0;
+
+    OS_AppTaskReturnHookPtr = (OS_APP_HOOK_TCB)0;
+
+    OS_AppTaskSwHookPtr     = (OS_APP_HOOK_VOID)0;
+
+    OS_AppTimeTickHookPtr   = (OS_APP_HOOK_VOID)0;
+    CPU_CRITICAL_EXIT();
+#endif
+}
+
+/*
+************************************************************************************************************************
+*                                              APPLICATION IDLE TASK HOOK
+*
+* Description: This function is called by the idle task.  This hook has been added to allow you to do such things as
+*              STOP the CPU to conserve power.
+*
+* Arguments  : none
+*
+* Note(s)    : none
+************************************************************************************************************************
+*/
+
+void  App_OS_IdleTaskHook (void)
+{
+    
+}
+
+/*
+************************************************************************************************************************
+*                                             APPLICATION REDZONE HIT HOOK
+*
+* Description: This function is called when a task's stack overflowed.
+*
+* Arguments  : p_tcb   is a pointer to the task control block of the offending task. NULL if ISR.
+*
+* Note(s)    : None.
+************************************************************************************************************************
+*/
+#if (OS_CFG_TASK_STK_REDZONE_EN > 0u)
+void  App_OS_RedzoneHitHook (OS_TCB  *p_tcb)
+{
+    (void)&p_tcb;
+    CPU_SW_EXCEPTION(;);
+}
+#endif
+
+
+/*
+************************************************************************************************************************
+*                                           APPLICATION STATISTIC TASK HOOK
+*
+* Description: This function is called every second by uC/OS-III's statistics task.  This allows your application to add
+*              functionality to the statistics task.
+*
+* Arguments  : none
+*
+* Note(s)    : none
+************************************************************************************************************************
+*/
+
+void  App_OS_StatTaskHook (void)
+{
+
+}
+
+
+/*
+************************************************************************************************************************
+*                                            APPLICATION TASK CREATION HOOK
+*
+* Description: This function is called when a task is created.
+*
+* Arguments  : p_tcb   is a pointer to the task control block of the task being created.
+*
+* Note(s)    : none
+************************************************************************************************************************
+*/
+
+void  App_OS_TaskCreateHook (OS_TCB  *p_tcb)
+{
+    (void)p_tcb;
+}
+
+
+/*
+************************************************************************************************************************
+*                                            APPLICATION TASK DELETION HOOK
+*
+* Description: This function is called when a task is deleted.
+*
+* Arguments  : p_tcb   is a pointer to the task control block of the task being deleted.
+*
+* Note(s)    : none
+************************************************************************************************************************
+*/
+
+void  App_OS_TaskDelHook (OS_TCB  *p_tcb)
+{
+    (void)p_tcb;
+}
+
+
+/*
+************************************************************************************************************************
+*                                             APPLICATION TASK RETURN HOOK
+*
+* Description: This function is called if a task accidentally returns.  In other words, a task should either be an
+*              infinite loop or delete itself when done.
+*
+* Arguments  : p_tcb     is a pointer to the OS_TCB of the task that is returning.
+*
+* Note(s)    : none
+************************************************************************************************************************
+*/
+
+void  App_OS_TaskReturnHook (OS_TCB  *p_tcb)
+{
+    (void)p_tcb;
+}
+
+
+/*
+************************************************************************************************************************
+*                                             APPLICATION TASK SWITCH HOOK
+*
+* Description: This function is called when a task switch is performed.  This allows you to perform other operations
+*              during a context switch.
+*
+* Arguments  : none
+*
+* Note(s)    : 1) Interrupts are disabled during this call.
+*              2) It is assumed that the global pointer 'OSTCBHighRdyPtr' points to the TCB of the task that will be
+*                 'switched in' (i.e. the highest priority task) and, 'OSTCBCurPtr' points to the task being switched out
+*                 (i.e. the preempted task).
+************************************************************************************************************************
+*/
+
+void  App_OS_TaskSwHook (void)
+{
+
+}
+
+
+/*
+************************************************************************************************************************
+*                                                APPLICATION TICK HOOK
+*
+* Description: This function is called every tick.
+*
+* Arguments  : none
+*
+* Note(s)    : 1) This function is assumed to be called from the Tick ISR.
+************************************************************************************************************************
+*/
+
+void  App_OS_TimeTickHook (void)
+{
+
+}

--- a/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/os_cfg/os_app_hooks.h
+++ b/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/os_cfg/os_app_hooks.h
@@ -1,0 +1,74 @@
+/*
+*********************************************************************************************************
+*                                              uC/OS-III
+*                                        The Real-Time Kernel
+*
+*                    Copyright 2009-2021 Silicon Laboratories Inc. www.silabs.com
+*
+*                                 SPDX-License-Identifier: APACHE-2.0
+*
+*               This software is subject to an open source license and is distributed by
+*                Silicon Laboratories Inc. pursuant to the terms of the Apache License,
+*                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
+*
+*********************************************************************************************************
+*/
+
+/*
+*********************************************************************************************************
+*
+*                                           APPLICATION HOOKS
+*
+* Filename : os_app_hooks.h
+* Version  : V3.08.01
+*********************************************************************************************************
+*/
+
+#ifndef  OS_APP_HOOKS_H
+#define  OS_APP_HOOKS_H
+
+
+#ifdef   OS_APP_HOOKS_H_GLOBALS
+#define  OS_APP_HOOKS_H_EXT
+#else
+#define  OS_APP_HOOKS_H_EXT  extern
+#endif
+
+/*
+************************************************************************************************************************
+*                                                 INCLUDE HEADER FILES
+************************************************************************************************************************
+*/
+
+#include <uCOS-III_Due.h>
+
+/*
+************************************************************************************************************************
+*                                                 FUNCTION PROTOTYPES
+************************************************************************************************************************
+*/
+
+void  App_OS_SetAllHooks   (void);
+void  App_OS_ClrAllHooks   (void);
+
+
+                                                                /* ---------------------- HOOKS --------------------- */
+void  App_OS_IdleTaskHook  (void);
+
+#if (OS_CFG_TASK_STK_REDZONE_EN > 0u)
+void  App_OS_RedzoneHitHook(OS_TCB  *p_tcb);
+#endif
+
+void  App_OS_StatTaskHook  (void);
+
+void  App_OS_TaskCreateHook(OS_TCB  *p_tcb);
+
+void  App_OS_TaskDelHook   (OS_TCB  *p_tcb);
+
+void  App_OS_TaskReturnHook(OS_TCB  *p_tcb);
+
+void  App_OS_TaskSwHook    (void);
+
+void  App_OS_TimeTickHook  (void);
+
+#endif

--- a/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/os_cfg/os_cfg.h
+++ b/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/os_cfg/os_cfg.h
@@ -1,0 +1,119 @@
+/*
+*********************************************************************************************************
+*                                              uC/OS-III
+*                                        The Real-Time Kernel
+*
+*                    Copyright 2009-2021 Silicon Laboratories Inc. www.silabs.com
+*
+*                                 SPDX-License-Identifier: APACHE-2.0
+*
+*               This software is subject to an open source license and is distributed by
+*                Silicon Laboratories Inc. pursuant to the terms of the Apache License,
+*                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
+*
+*********************************************************************************************************
+*/
+
+/*
+*********************************************************************************************************
+*
+*                                          CONFIGURATION FILE
+*
+* Filename : os_cfg.h
+* Version  : V3.08.01
+*********************************************************************************************************
+*/
+
+#ifndef OS_CFG_H
+#define OS_CFG_H
+
+                                                                /* --------------------------- MISCELLANEOUS --------------------------- */
+#define OS_CFG_APP_HOOKS_EN                        1u           /* Enable (1) or Disable (0) application specific hooks                  */
+#define OS_CFG_ARG_CHK_EN                          1u           /* Enable (1) or Disable (0) argument checking                           */
+#define OS_CFG_CALLED_FROM_ISR_CHK_EN              1u           /* Enable (1) or Disable (0) check for called from ISR                   */
+#define OS_CFG_DBG_EN                              0u           /* Enable (1) or Disable (0) debug code/variables                        */
+#define OS_CFG_TICK_EN                             1u           /* Enable (1) or Disable (0) the kernel tick                             */
+#define OS_CFG_DYN_TICK_EN                         0u           /* Enable (1) or Disable (0) the Dynamic Tick                            */
+#define OS_CFG_INVALID_OS_CALLS_CHK_EN             1u           /* Enable (1) or Disable (0) checks for invalid kernel calls             */
+#define OS_CFG_OBJ_TYPE_CHK_EN                     1u           /* Enable (1) or Disable (0) object type checking                        */
+#define OS_CFG_OBJ_CREATED_CHK_EN                  1u           /* Enable (1) or Disable (0) object created checks                       */
+#define OS_CFG_TS_EN                               0u           /* Enable (1) or Disable (0) time stamping                               */
+
+#define OS_CFG_PRIO_MAX                           64u           /* Defines the maximum number of task priorities (see OS_PRIO data type) */
+
+#define OS_CFG_SCHED_LOCK_TIME_MEAS_EN             0u           /* Include code to measure scheduler lock time                           */
+#define OS_CFG_SCHED_ROUND_ROBIN_EN                1u           /* Include code for Round-Robin scheduling                               */
+
+#define OS_CFG_STK_SIZE_MIN                       64u           /* Minimum allowable task stack size                                     */
+
+
+                                                                /* --------------------------- EVENT FLAGS ----------------------------- */
+#define OS_CFG_FLAG_EN                             1u           /* Enable (1) or Disable (0) code generation for EVENT FLAGS             */
+#define OS_CFG_FLAG_DEL_EN                         1u           /*     Include code for OSFlagDel()                                      */
+#define OS_CFG_FLAG_MODE_CLR_EN                    1u           /*     Include code for Wait on Clear EVENT FLAGS                        */
+#define OS_CFG_FLAG_PEND_ABORT_EN                  1u           /*     Include code for OSFlagPendAbort()                                */
+
+
+                                                                /* ------------------------ MEMORY MANAGEMENT -------------------------  */
+#define OS_CFG_MEM_EN                              1u           /* Enable (1) or Disable (0) code generation for the MEMORY MANAGER      */
+
+
+                                                                /* ------------------- MUTUAL EXCLUSION SEMAPHORES --------------------  */
+#define OS_CFG_MUTEX_EN                            1u           /* Enable (1) or Disable (0) code generation for MUTEX                   */
+#define OS_CFG_MUTEX_DEL_EN                        1u           /*     Include code for OSMutexDel()                                     */
+#define OS_CFG_MUTEX_PEND_ABORT_EN                 1u           /*     Include code for OSMutexPendAbort()                               */
+
+
+                                                                /* -------------------------- MESSAGE QUEUES --------------------------  */
+#define OS_CFG_Q_EN                                1u           /* Enable (1) or Disable (0) code generation for QUEUES                  */
+#define OS_CFG_Q_DEL_EN                            1u           /*     Include code for OSQDel()                                         */
+#define OS_CFG_Q_FLUSH_EN                          1u           /*     Include code for OSQFlush()                                       */
+#define OS_CFG_Q_PEND_ABORT_EN                     1u           /*     Include code for OSQPendAbort()                                   */
+
+
+                                                                /* ---------------------------- SEMAPHORES ----------------------------- */
+#define OS_CFG_SEM_EN                              1u           /* Enable (1) or Disable (0) code generation for SEMAPHORES              */
+#define OS_CFG_SEM_DEL_EN                          1u           /*     Include code for OSSemDel()                                       */
+#define OS_CFG_SEM_PEND_ABORT_EN                   1u           /*     Include code for OSSemPendAbort()                                 */
+#define OS_CFG_SEM_SET_EN                          1u           /*     Include code for OSSemSet()                                       */
+
+
+                                                                /* -------------------------- TASK MANAGEMENT -------------------------- */
+#define OS_CFG_STAT_TASK_EN                        1u           /* Enable (1) or Disable (0) the statistics task                         */
+#define OS_CFG_STAT_TASK_STK_CHK_EN                1u           /*     Check task stacks from the statistic task                         */
+
+#define OS_CFG_TASK_CHANGE_PRIO_EN                 1u           /* Include code for OSTaskChangePrio()                                   */
+#define OS_CFG_TASK_DEL_EN                         1u           /* Include code for OSTaskDel()                                          */
+#define OS_CFG_TASK_IDLE_EN                        1u           /* Include the idle task                                                 */
+#define OS_CFG_TASK_PROFILE_EN                     1u           /* Include variables in OS_TCB for profiling                             */
+#define OS_CFG_TASK_Q_EN                           0u           /* Include code for OSTaskQXXXX()                                        */
+#define OS_CFG_TASK_Q_PEND_ABORT_EN                1u           /* Include code for OSTaskQPendAbort()                                   */
+#define OS_CFG_TASK_REG_TBL_SIZE                   1u           /* Number of task specific registers                                     */
+
+#define OS_CFG_TASK_STK_REDZONE_EN                 0u           /* Enable (1) or Disable (0) stack redzone                               */
+#define OS_CFG_TASK_STK_REDZONE_DEPTH              8u           /* Depth of the stack redzone                                            */
+
+#define OS_CFG_TASK_SEM_PEND_ABORT_EN              1u           /* Include code for OSTaskSemPendAbort()                                 */
+#define OS_CFG_TASK_SUSPEND_EN                     1u           /* Include code for OSTaskSuspend() and OSTaskResume()                   */
+
+
+                                                                /* ------------------ TASK LOCAL STORAGE MANAGEMENT -------------------  */
+#define OS_CFG_TLS_TBL_SIZE                        0u           /* Include code for Task Local Storage (TLS) registers                   */
+
+
+                                                                /* ------------------------- TIME MANAGEMENT --------------------------  */
+#define OS_CFG_TIME_DLY_HMSM_EN                    1u           /* Include code for OSTimeDlyHMSM()                                      */
+#define OS_CFG_TIME_DLY_RESUME_EN                  1u           /* Include code for OSTimeDlyResume()                                    */
+
+
+                                                                /* ------------------------- TIMER MANAGEMENT -------------------------- */
+#define OS_CFG_TMR_EN                              1u           /* Enable (1) or Disable (0) code generation for TIMERS                  */
+#define OS_CFG_TMR_DEL_EN                          1u           /* Enable (1) or Disable (0) code generation for OSTmrDel()              */
+
+
+                                                                /* ------------------------- TRACE RECORDER ---------------------------- */
+#define OS_CFG_TRACE_EN                            0u           /* Enable (1) or Disable (0) uC/OS-III Trace instrumentation             */
+#define OS_CFG_TRACE_API_ENTER_EN                  0u           /* Enable (1) or Disable (0) uC/OS-III Trace API enter instrumentation   */
+#define OS_CFG_TRACE_API_EXIT_EN                   0u           /* Enable (1) or Disable (0) uC/OS-III Trace API exit  instrumentation   */
+
+#endif

--- a/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/os_cfg/os_cfg_app.h
+++ b/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/os_cfg/os_cfg_app.h
@@ -1,0 +1,80 @@
+/*
+*********************************************************************************************************
+*                                              uC/OS-III
+*                                        The Real-Time Kernel
+*
+*                    Copyright 2009-2021 Silicon Laboratories Inc. www.silabs.com
+*
+*                                 SPDX-License-Identifier: APACHE-2.0
+*
+*               This software is subject to an open source license and is distributed by
+*                Silicon Laboratories Inc. pursuant to the terms of the Apache License,
+*                    Version 2.0 available at www.apache.org/licenses/LICENSE-2.0.
+*
+*********************************************************************************************************
+*/
+
+/*
+*********************************************************************************************************
+*
+*                               OS CONFIGURATION (APPLICATION SPECIFICS)
+*
+* Filename : os_cfg_app.h
+* Version  : V3.08.01
+*********************************************************************************************************
+*/
+
+#ifndef OS_CFG_APP_H
+#define OS_CFG_APP_H
+
+/*
+**************************************************************************************************************************
+*                                                      CONSTANTS
+**************************************************************************************************************************
+*/
+                                                                /* ------------------ MISCELLANEOUS ------------------- */
+                                                                /* Stack size of ISR stack (number of CPU_STK elements) */
+#define  OS_CFG_ISR_STK_SIZE                             128u
+                                                                /* Maximum number of messages                           */
+#define  OS_CFG_MSG_POOL_SIZE                             32u
+                                                                /* Stack limit position in percentage to empty          */
+#define  OS_CFG_TASK_STK_LIMIT_PCT_EMPTY                  10u
+
+
+                                                                /* -------------------- IDLE TASK --------------------- */
+                                                                /* Stack size (number of CPU_STK elements)              */
+#define  OS_CFG_IDLE_TASK_STK_SIZE                        64u
+
+
+                                                                /* ------------------ STATISTIC TASK ------------------ */
+                                                                /* Priority                                             */
+#define  OS_CFG_STAT_TASK_PRIO  ((OS_PRIO)(OS_CFG_PRIO_MAX-2u))
+                                                                /* Rate of execution (1 to 10 Hz)                       */
+#define  OS_CFG_STAT_TASK_RATE_HZ                         10u
+                                                                /* Stack size (number of CPU_STK elements)              */
+#define  OS_CFG_STAT_TASK_STK_SIZE                       100u
+
+
+                                                                /* ---------------------- TICKS ----------------------- */
+                                                                /* Tick rate in Hertz (10 to 1000 Hz)                   */
+#define  OS_CFG_TICK_RATE_HZ                            1000u
+
+
+                                                                /* --------------------- TIMERS ----------------------- */
+                                                                /* Priority of 'Timer Task'                             */
+#define  OS_CFG_TMR_TASK_PRIO   ((OS_PRIO)(OS_CFG_PRIO_MAX-3u))
+                                                                /* Stack size (number of CPU_STK elements)              */
+#define  OS_CFG_TMR_TASK_STK_SIZE                        128u
+
+                                                                /* DEPRECATED - Rate for timers (10 Hz Typ.)            */
+                                                                /* The timer task now calculates its timeouts based     */
+                                                                /* on the timers in the list. It no longer runs at a    */
+                                                                /* static frequency.                                    */
+                                                                /* This define is included for compatibility reasons.   */
+                                                                /* It will determine the period of a timer tick.        */
+                                                                /* We recommend setting it to OS_CFG_TICK_RATE_HZ       */
+                                                                /* for new projects.                                    */
+#define  OS_CFG_TMR_TASK_RATE_HZ                          10u
+
+
+#endif

--- a/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/qs_bsp.cpp
+++ b/examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii/qs_bsp.cpp
@@ -1,0 +1,61 @@
+#include "qpcpp.hpp"  // QP-C++ framework
+#include <Arduino.h>
+
+//#define QS_ON
+
+constexpr int QsTXBuffer_KB = 10; //Units are in Kilobytes
+constexpr int QsRXBuffer_B  = 500;//Units are in bytes
+bool QP::QS::onStartup(void const * arg)
+{
+
+  static uint8_t qsTxBuf[QsTXBuffer_KB * 1024]; // buffer for QS transmit channel
+  static uint8_t qsRxBuf[QsRXBuffer_B];    // buffer for QS receive channel
+  initBuf  (qsTxBuf, sizeof(qsTxBuf));
+  rxInitBuf(qsRxBuf, sizeof(qsRxBuf));
+#ifdef QS_ON
+  QS_GLB_FILTER(QP::QS_AO_RECORDS); // active object records
+  QS_GLB_FILTER(QP::QS_SM_RECORDS); // state machine records
+#endif
+  return true; // return success
+}
+
+void QP::QS::onCommand(uint8_t cmdId, uint32_t param1,
+                       uint32_t param2, uint32_t param3)
+{
+  (void)cmdId;
+  (void)param1;
+  (void)param2;
+  (void)param3;
+  //Handling of User Commands from Qspy should go here
+}
+
+
+void QP::QS::onCleanup(void)
+{
+
+}
+
+QP::QSTimeCtr QP::QS::onGetTime(void)
+{
+  return millis();
+}
+
+void QP::QS::onFlush(void)
+{
+#ifdef QS_ON
+  uint16_t len = 0xFFFFU; // big number to get as many bytes as available
+  uint8_t const *buf = QS::getBlock(&len); // get continguous block of data
+  while (buf != nullptr)
+  { // data available?
+    Serial.write(buf, len); // might poll until all bytes fit
+    len = 0xFFFFU; // big number to get as many bytes as available
+    buf = QS::getBlock(&len); // try to get more data
+  }
+  Serial.flush(); // wait for the transmission of outgoing data to complete
+#endif
+}
+
+void QP::QS::onReset(void)
+{
+  NVIC_SystemReset();
+}

--- a/ports/ucos-iii/qep_port.hpp
+++ b/ports/ucos-iii/qep_port.hpp
@@ -1,0 +1,45 @@
+/// @file
+/// @brief QEP/C++ port, generic C++11 compiler
+/// @cond
+///***************************************************************************
+/// Last updated for version 6.8.0
+/// Last updated on  2020-01-13
+///
+///                    Q u a n t u m  L e a P s
+///                    ------------------------
+///                    Modern Embedded Software
+///
+/// Copyright (C) 2005-2020 Quantum Leaps. All rights reserved.
+///
+/// This program is open source software: you can redistribute it and/or
+/// modify it under the terms of the GNU General Public License as published
+/// by the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// Alternatively, this program may be distributed and modified under the
+/// terms of Quantum Leaps commercial licenses, which expressly supersede
+/// the GNU General Public License and are specifically designed for
+/// licensees interested in retaining the proprietary status of their code.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program. If not, see <www.gnu.org/licenses>.
+///
+/// Contact information:
+/// <www.state-machine.com/licensing>
+/// <info@state-machine.com>
+///***************************************************************************
+/// @endcond
+
+#ifndef QEP_PORT_HPP
+#define QEP_PORT_HPP
+
+#include <cstdint>  // Exact-width types. C++11 Standard
+
+#include "qep.hpp"  // QEP platform-independent public interface
+
+#endif // QEP_PORT_HPP

--- a/ports/ucos-iii/qf_port.cpp
+++ b/ports/ucos-iii/qf_port.cpp
@@ -1,0 +1,376 @@
+/// @file
+/// @brief QF/C++ port to uC/OS-III RTOS, all supported compilers
+/// @cond
+///***************************************************************************
+/// Last updated for version 6.9.3
+/// Last updated on  2021-04-08
+///
+///                    Q u a n t u m  L e a P s
+///                    ------------------------
+///                    Modern Embedded Software
+///
+/// Copyright (C) 2005-2021 Quantum Leaps. All rights reserved.
+///
+/// This program is open source software: you can redistribute it and/or
+/// modify it under the terms of the GNU General Public License as published
+/// by the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// Alternatively, this program may be distributed and modified under the
+/// terms of Quantum Leaps commercial licenses, which expressly supersede
+/// the GNU General Public License and are specifically designed for
+/// licensees interested in retaining the proprietary status of their code.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program. If not, see <www.gnu.org/licenses>.
+///
+/// Contact information:
+/// <www.state-machine.com/licensing>
+/// <info@state-machine.com>
+///***************************************************************************
+/// @endcond
+
+#define QP_IMPL             // this is QP implementation
+#include "qf_port.hpp"      // QF port
+#include "qf_pkg.hpp"
+#include "qassert.h"
+#ifdef Q_SPY                // QS software tracing enabled?
+    #include "qs_port.hpp"  // QS port
+    #include "qs_pkg.hpp"   // QS package-scope internal interface
+#else
+    #include "qs_dummy.hpp" // disable the QS software tracing
+#endif // Q_SPY
+
+
+// namespace QP ==============================================================
+namespace QP {
+
+Q_DEFINE_THIS_MODULE("qf_port")
+
+// Local objects -------------------------------------------------------------
+static void task_function(void *pdata); // uC/OS-III task signature
+
+//............................................................................
+void QF::init(void) {
+    OS_ERR err;
+    OSInit(&err);        // initialize uC/OS-III
+    Q_ASSERT_ID(50, err == OS_ERR_NONE);
+}
+//............................................................................
+int_t QF::run(void) {
+    onStartup();     // configure & start interrupts, see NOTE0
+
+    // produce the QS_QF_RUN trace record
+    QS_CRIT_STAT_
+    QS_BEGIN_PRE_(QS_QF_RUN, 0U)
+    QS_END_PRE_()
+    OS_ERR err;
+    OSStart(&err);       // start uC/OS-III multitasking
+    Q_ASSERT_ID(100, err == OS_ERR_NONE);  
+    return 0; // dummy return to make the compiler happy
+}
+//............................................................................
+void QF::stop(void) {
+    onCleanup();  // cleanup callback
+}
+
+//............................................................................
+void QActive::start(std::uint_fast8_t const prio,
+                    QEvt const * * const qSto, std::uint_fast16_t const qLen,
+                    void * const stkSto, std::uint_fast16_t const stkSize,
+                    void const * const par)
+{
+    // task name to be passed to OSTaskCreate()
+    void *task_name = static_cast<void *>(m_eQueue);
+    //Task options to be passed to OSTaskCreate()
+    OS_OPT  * task_opt = static_cast<OS_OPT*>(static_cast<void *>(m_thread));
+
+    OS_ERR err;
+
+    m_prio = prio;  // save the QF priority
+    QF::add_(this); // make QF aware of this active object
+    
+
+    init(par, m_prio); // take the top-most initial tran.
+    QS_FLUSH();     // flush the trace buffer to the host
+
+#if (OS_CFG_TASK_Q_EN > 0u) //If os doesnt use internal Task queue
+    static OS_TCB task_tcb;
+    m_thread = &task_tcb;
+#else
+    static OS_Q os_q;
+    m_eQueue = &os_q;
+    // create uC/OS-III queue and make sure it was created correctly
+    char qName[] = "qAOxx";
+    qName[3] = '0' + (m_prio / 10U);
+    qName[4] = '0' + (m_prio % 10U);
+    OSQCreate(m_eQueue, qName,qLen,&err);
+    Q_ASSERT_ID(210, err == OS_ERR_NONE);
+
+#endif
+
+    // map from QP to uC/OS-III priority
+    OS_PRIO p_ucos = static_cast<OS_PRIO>(QF_MAX_ACTIVE - m_prio);
+    const CPU_STK_SIZE stk_size = (stkSize/sizeof(CPU_STK));
+
+    // create AO's task...
+    //
+    // NOTE: The call to uC/OS-III API OSTaskCreate() assumes that the
+    // pointer to the top-of-stack (ptos) is at the end of the provided
+    // stack memory. This is correct only for CPUs with downward-growing
+    // stack, but must be changed for CPUs with upward-growing stack
+    //
+#if OS_STK_GROWTH == 1u
+    CPU_STK * pStack = static_cast<CPU_STK*>(stkSto);
+#else
+    CPU_STK * pStack = &static_cast<CPU_STK*>(stkSto)[stk_size-1];           
+#endif
+    OSTaskCreate(m_thread,
+                 static_cast<CPU_CHAR *>(task_name),
+                 task_function,
+                 this,
+                 p_ucos, // the unique QP priority is the task id
+                 pStack,
+                 stk_size/10, //Stack limit
+                 stk_size,// size in OS_STK units
+#if (OS_CFG_TASK_Q_EN > 0u)
+                 static_cast<OS_MSG_QTY>(qLen), //internal Task message Queue, used only if 
+#else
+                 static_cast<OS_MSG_QTY>(0),
+#endif
+                 static_cast<OS_TICK>(0), //time_quanta
+                 static_cast<void *>(0), //TCB extension
+                 *task_opt,
+                 &err);
+
+    // uC/OS-III task must be created correctly
+    Q_ENSURE_ID(220, err == OS_ERR_NONE);
+}
+//............................................................................
+// NOTE: This function must be called BEFORE starting an active object
+void QActive::setAttr(std::uint32_t attr1, void const *attr2) {
+    switch (attr1) {
+        case TASK_NAME_ATTR:
+           // this function must be called before QACTIVE_START(),
+           // which implies that me->eQueue must not be used yet;
+           Q_ASSERT_ID(300, m_eQueue == nullptr);
+           // temporarily store the name, cast 'const' away
+           m_eQueue = static_cast<OS_Q *>(
+                           const_cast<void *>(attr2));
+       case TASK_OPT_ATTR:
+       default:
+            // temporarily store the task options, cast 'const' away
+            m_thread = static_cast<OS_TCB *>(
+                           const_cast<void *>(attr2));
+            break;
+       
+    }
+}
+
+// thread for active objects -------------------------------------------------
+void QF::thread_(QActive *act) {
+    // event-loop
+    for (;;) { // for-ever
+        QEvt const *e = act->get_(); // wait for event
+        act->dispatch(e, act->m_prio); // dispatch to the AO's state machine
+        gc(e); // check if the event is garbage, and collect it if so
+    }
+}
+//............................................................................
+static void task_function(void *pdata) { // uC/OS-III task signature
+    QActive *act = reinterpret_cast<QActive *>(pdata);
+
+    QF::thread_(act);
+    QF::remove_(act); // remove this object from QF
+    OS_ERR err;
+    OSTaskDel(act->m_thread,&err); // make uC/OS-III forget about this task
+}
+//............................................................................
+#ifndef Q_SPY
+bool QActive::post_(QEvt const * const e,
+                    std::uint_fast16_t const margin) noexcept
+#else
+bool QActive::post_(QEvt const * const e, std::uint_fast16_t const margin,
+                    void const * const sender) noexcept
+#endif
+{
+    bool status;
+    std::uint_fast16_t nFree;
+    QF_CRIT_STAT_
+
+    QF_CRIT_E_();
+#if (OS_CFG_TASK_Q_EN > 0u) //If os uses internal queue
+    nFree = static_cast<std::uint_fast16_t>(
+            m_thread->MsgQ.NbrEntriesSize
+             - m_thread->MsgQ.NbrEntries);
+#else
+    nFree = static_cast<std::uint_fast16_t>(
+            reinterpret_cast<OS_Q *>(m_eQueue)->MsgQ.NbrEntriesSize
+             - reinterpret_cast<OS_Q *>(m_eQueue)->MsgQ.NbrEntries);
+#endif
+
+  
+    if (margin == QF_NO_MARGIN) {
+        if (nFree > static_cast<QEQueueCtr>(0)) {
+            status = true; // can post
+        }
+        else {
+            status = false; // cannot post
+            Q_ERROR_ID(710); // must be able to post the event
+        }
+    }
+    else if (nFree > static_cast<QEQueueCtr>(margin)) {
+        status = true; // can post
+    }
+    else {
+        status = false; // cannot post
+    }
+
+    if (status) { // can post the event?
+
+        QS_BEGIN_NOCRIT_PRE_(QS_QF_ACTIVE_POST, m_prio)
+            QS_TIME_PRE_();      // timestamp
+            QS_OBJ_PRE_(sender); // the sender object
+            QS_SIG_PRE_(e->sig); // the signal of the event
+            QS_OBJ_PRE_(this);   // this active object (recipient)
+            QS_2U8_PRE_(e->poolId_, e->refCtr_); // pool Id & ref Count
+            QS_EQC_PRE_(nFree);  // # free entries
+            QS_EQC_PRE_(0U);     // min # free (unknown)
+        QS_END_NOCRIT_PRE_()
+
+        if (e->poolId_ != 0U) { // is it a pool event?
+            QF_EVT_REF_CTR_INC_(e); // increment the reference counter
+        }
+
+        QF_CRIT_X_();
+        OS_ERR err;
+#if (OS_CFG_TASK_Q_EN > 0u) //If os uses internal queue
+        OSTaskQPost(m_thread,
+#else
+        OSQPost (   m_eQueue,
+#endif
+                    const_cast<QEvt *>(e), //Message to send
+                    sizeof(QEvt), //Message size
+                    OS_OPT_POST_FIFO,
+                    &err);
+        // posting the event to uC/OS-III message queue must succeed
+        Q_ALLEGE_ID(720, err  == OS_ERR_NONE);
+    }
+    else {
+
+        QS_BEGIN_NOCRIT_PRE_(QS_QF_ACTIVE_POST_ATTEMPT, m_prio)
+            QS_TIME_PRE_();      // timestamp
+            QS_OBJ_PRE_(sender); // the sender object
+            QS_SIG_PRE_(e->sig); // the signal of the event
+            QS_OBJ_PRE_(this);   // this active object (recipient)
+            QS_2U8_PRE_(e->poolId_, e->refCtr_); // pool Id & ref Count
+            QS_EQC_PRE_(nFree);  // # free entries
+            QS_EQC_PRE_(0U);     // min # free (unknown)
+        QS_END_NOCRIT_PRE_()
+
+        QF_CRIT_X_();
+    }
+
+    return status;
+}
+//............................................................................
+void QActive::postLIFO(QEvt const * const e) noexcept {
+    QF_CRIT_STAT_
+    QF_CRIT_E_();
+    
+    QS_BEGIN_NOCRIT_PRE_(QS_QF_ACTIVE_POST_LIFO, m_prio)
+        QS_TIME_PRE_();       // timestamp
+        QS_SIG_PRE_(e->sig);  // the signal of this event
+        QS_OBJ_PRE_(this);    // this active object
+        QS_2U8_PRE_(e->poolId_, e->refCtr_); // pool Id & ref Count
+                              // # free entries
+#if (OS_CFG_TASK_Q_EN > 0u) //If os uses internal queue
+        QS_EQC_PRE_(m_thread->MsgQ.NbrEntriesSize
+                    - m_thread->MsgQ.NbrEntries);
+#else
+        QS_EQC_PRE_(reinterpret_cast<OS_Q *>(m_eQueue)->MsgQ.NbrEntriesSize
+                    - reinterpret_cast<OS_Q *>(m_eQueue)->MsgQ.NbrEntries);
+#endif
+       
+        QS_EQC_PRE_(0U);      // min # free (unknown)
+    QS_END_NOCRIT_PRE_()
+
+    if (e->poolId_ != 0U) { // is it a pool event?
+        QF_EVT_REF_CTR_INC_(e); // increment the reference counter
+    }
+
+    QF_CRIT_X_();
+    OS_ERR err;
+    
+#if (OS_CFG_TASK_Q_EN > 0u) //If os uses internal queue
+    OSTaskQPost(m_thread,
+#else
+    OSQPost (   m_eQueue,
+#endif
+                const_cast<QEvt *>(e), //Message to send
+                sizeof(QEvt), //Message size
+                OS_OPT_POST_LIFO,
+                &err);
+    // posting the event to uC/OS-III message queue must succeed
+    Q_ALLEGE_ID(810, err == OS_ERR_NONE);
+}
+//............................................................................
+
+QEvt const *QActive::get_(void) noexcept {
+    OS_ERR err;
+    QS_CRIT_STAT_
+    OS_MSG_SIZE msg_size;
+    CPU_TS ts;
+    QEvt const *e = static_cast<QEvt const *>(
+#if (OS_CFG_TASK_Q_EN > 0u) //If os uses internal queue
+    OSTaskQPend(
+#else
+    OSQPend (   m_eQueue,
+#endif
+                    0U,         //timeout
+                    OS_OPT_PEND_BLOCKING, //Pend type
+                    &msg_size, 
+                    &ts, //Timestamp
+                    &err));
+    Q_ASSERT_ID(910, err == OS_ERR_NONE);
+
+    QS_BEGIN_PRE_(QS_QF_ACTIVE_GET, m_prio)
+        QS_TIME_PRE_();       // timestamp
+        QS_SIG_PRE_(e->sig);  // the signal of this event
+        QS_OBJ_PRE_(this);    // this active object
+        QS_2U8_PRE_(e->poolId_, e->refCtr_); // pool Id & ref Count
+                              // # free entries
+#if (OS_CFG_TASK_Q_EN > 0u) //If os uses internal queue
+        QS_EQC_PRE_(m_thread->MsgQ.NbrEntriesSize
+                    - m_thread->MsgQ.NbrEntries);
+#else
+        QS_EQC_PRE_(reinterpret_cast<OS_Q *>(m_eQueue)->MsgQ.NbrEntriesSize
+                    - reinterpret_cast<OS_Q *>(m_eQueue)->MsgQ.NbrEntries);
+#endif
+    QS_END_PRE_()
+
+    return e;
+}
+
+} // namespace QP
+
+///***************************************************************************
+// NOTE0:
+// The QF_onStartup() should enter the critical section before configuring
+// and starting interrupts and it should NOT exit the critical section.
+// Thus the interrupts cannot fire until uC/OS-III starts multitasking
+// in OSStart(). This is to prevent a (narrow) time window in which interrupts
+// could make some tasks ready to run, but the OS would not be ready yet
+// to perform context switch.
+//
+// NOTE1:
+// The member QActive.thread is set to the uC/OS-III task options in the
+// function QF_setUCosTaskAttr(), which must be called **before**
+// QActive::start().
+//
+

--- a/ports/ucos-iii/qf_port.cpp
+++ b/ports/ucos-iii/qf_port.cpp
@@ -98,11 +98,9 @@ void QActive::start(std::uint_fast8_t const prio,
 
     init(par, m_prio); // take the top-most initial tran.
     QS_FLUSH();     // flush the trace buffer to the host
-
-#if (OS_CFG_TASK_Q_EN > 0u) //If os doesnt use internal Task queue
     static OS_TCB task_tcb;
     m_thread = &task_tcb;
-#else
+#if (OS_CFG_TASK_Q_EN == 0u) //If os doesnt use internal Task queue
     static OS_Q os_q;
     m_eQueue = &os_q;
     // create uC/OS-III queue and make sure it was created correctly
@@ -111,7 +109,6 @@ void QActive::start(std::uint_fast8_t const prio,
     qName[4] = '0' + (m_prio % 10U);
     OSQCreate(m_eQueue, qName,qLen,&err);
     Q_ASSERT_ID(210, err == OS_ERR_NONE);
-
 #endif
 
     // map from QP to uC/OS-III priority

--- a/ports/ucos-iii/qf_port.hpp
+++ b/ports/ucos-iii/qf_port.hpp
@@ -39,8 +39,8 @@
 #define QF_PORT_HPP
 
 // uC/OS-II event queue and thread types
-#define QF_EQUEUE_TYPE       OS_Q*
-#define QF_THREAD_TYPE       OS_TCB*
+#define QF_EQUEUE_TYPE       OS_Q
+#define QF_THREAD_TYPE       OS_TCB
 // The maximum number of active objects in the application
 #define QF_MAX_ACTIVE ((OS_CFG_PRIO_MAX - 2 < 64) ? (OS_CFG_PRIO_MAX - 2) : 64U)
 

--- a/ports/ucos-iii/qf_port.hpp
+++ b/ports/ucos-iii/qf_port.hpp
@@ -1,0 +1,203 @@
+/// @file
+/// @brief QF/C++ port to uC/OS-III (V3.08) kernel, all supported compilers
+/// @cond
+///***************************************************************************
+/// Last updated for version 6.9.3
+/// Last updated on  2021-04-08
+///
+///                    Q u a n t u m  L e a P s
+///                    ------------------------
+///                    Modern Embedded Software
+///
+/// Copyright (C) 2005-2021 Quantum Leaps. All rights reserved.
+///
+/// This program is open source software: you can redistribute it and/or
+/// modify it under the terms of the GNU General Public License as published
+/// by the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// Alternatively, this program may be distributed and modified under the
+/// terms of Quantum Leaps commercial licenses, which expressly supersede
+/// the GNU General Public License and are specifically designed for
+/// licensees interested in retaining the proprietary status of their code.
+///
+/// This program is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with this program. If not, see <www.gnu.org/licenses>.
+///
+/// Contact information:
+/// <www.state-machine.com/licensing>
+/// <info@state-machine.com>
+///***************************************************************************
+/// @endcond
+
+#ifndef QF_PORT_HPP
+#define QF_PORT_HPP
+
+// uC/OS-II event queue and thread types
+#define QF_EQUEUE_TYPE       OS_Q*
+#define QF_THREAD_TYPE       OS_TCB*
+// The maximum number of active objects in the application
+#define QF_MAX_ACTIVE ((OS_CFG_PRIO_MAX - 2 < 64) ? (OS_CFG_PRIO_MAX - 2) : 64U)
+
+#include "os.h" // uC/OS-III API, port and compile-time configuration
+                                  
+
+// uC/OS-III crtitical section, NOTE1
+#if (CPU_CFG_CRITICAL_METHOD == CPU_CRITICAL_METHOD_INT_DIS_EN)
+    /* QF_CRIT_STAT_TYPE  not defined */
+    #define QF_CRIT_ENTRY(dummy) CPU_CRITICAL_ENTER()
+    #define QF_CRIT_EXIT(dummy)  CPU_CRITICAL_EXIT()
+#elif (CPU_CFG_CRITICAL_METHOD == CPU_CRITICAL_METHOD_STATUS_LOCAL)
+    #define QF_CRIT_STAT_TYPE    CPU_SR
+    #define QF_CRIT_ENTRY(dummy) CPU_CRITICAL_ENTER()
+    #define QF_CRIT_EXIT(dummy)  CPU_CRITICAL_EXIT()
+#else
+    #error Unsupported uC/OS-III critical section type
+#endif // CPU_CFG_CRITICAL_METHOD
+
+namespace QP {
+                                           
+                                                 
+                                                
+
+enum UCOS3_TaskAttrs {
+    TASK_NAME_ATTR,
+    TASK_OPT_ATTR
+};
+
+} // namespace QP
+                                      
+
+#include "qep_port.hpp"  // QEP port, includes the master uC/OS-II include
+#include "qequeue.hpp"   // used for event deferral
+#include "qmpool.hpp"    // native QF event pool
+#include "qpset.hpp"     // this QP port uses the native QP priority set
+#include "qf.hpp"        // QF platform-independent public interface
+
+                                                                         
+                                   
+
+//****************************************************************************
+// interface used only inside QF, but not in applications
+//
+#ifdef QP_IMPL
+
+    // uC/OS-II crtitical section, NOTE1
+#if (CPU_CFG_CRITICAL_METHOD == CPU_CRITICAL_METHOD_STATUS_LOCAL)
+    /* internal uC/OS-II critical section operations, NOTE1 */
+    #define QF_CRIT_STAT_       CPU_SR cpu_sr;
+    #define QF_CRIT_E_()    CPU_CRITICAL_ENTER()
+    #define QF_CRIT_X_()     CPU_CRITICAL_EXIT()
+#endif // CPU_CFG_CRITICAL_METHOD
+
+    // uC/OS-II-specific scheduler locking, see NOTE2
+    #define QF_SCHED_STAT_
+    #define QF_SCHED_LOCK_(dummy) do { \
+        if (OSIntNestingCtr == 0) {    \
+            OS_ERR err;               \
+            OSSchedLock(&err);         \
+        }                              \
+    } while (false)
+
+    #define QF_SCHED_UNLOCK_() do { \
+        if (OSIntNestingCtr == 0) {    \
+            OS_ERR err;               \
+            OSSchedLock(&err);         \
+        } \
+    } while (false)
+
+    // uC/OS-III event pool operations...
+    #define QF_EPOOL_TYPE_ OS_MEM*
+    #define QF_EPOOL_INIT_(pool_, poolSto_, poolSize_, evtSize_) do {       \
+        OS_ERR err;                                                          \
+        OSMemCreate((pool_),"EPool",(poolSto_),(CPU_INT32U)((poolSize_)/(evtSize_)), \
+                              (CPU_INT32U)(evtSize_), &err);                    \
+        Q_ASSERT_ID(105, err == OS_ERR_NONE);                               \
+    } while (false)
+
+    #define QF_EPOOL_EVENT_SIZE_(pool_) ((pool_)->BlkSize)
+    #define QF_EPOOL_GET_(pool_, e_, m_, qs_id_) do { \
+        QF_CRIT_STAT_                                 \
+        QF_CRIT_E_();                                 \
+        if ((pool_)->NbrFree > (m_)) {             \
+            OS_ERR err;                                \
+            (e_) = (QEvt *)OSMemGet((pool_), &err);   \
+            Q_ASSERT_ID(205, err == OS_ERR_NONE);     \
+        }                                             \
+        else {                                        \
+            (e_) = nullptr;                           \
+        }                                             \
+        QF_CRIT_X_();                                 \
+    } while (false)
+
+    #define QF_EPOOL_PUT_(pool_, e_, qs_id_)    \
+        OS_ERR err;                             \
+        OSMemPut((pool_), (e_),&err);           \
+        Q_ALLEGE_ID(305, err == OS_ERR_NONE)
+
+#endif // ifdef QP_IMPL
+
+                                   
+
+                                                       
+                                            
+                                                 
+                                       
+
+                                  
+                                                                   
+                                                                
+
+//****************************************************************************
+// NOTE1:
+// This QP port to uC/OS-III re-uses the exact same critical section mechanism
+// as uC/OS-II. The goal is to make this port independent on the CPU or the
+// toolchain by employing only the official uC/OS-II API. That way, all CPU
+// and toolchain dependencies are handled internally by uC/OS-II.
+//
+// NOTE2:
+// uC/OS-II provides only global scheduler locking for all thread priorities
+// by means of OSSchedLock() and OSSchedUnlock(). Therefore, locking the
+// scheduler only up to the specified lock priority is not supported.
+              
+//
+         
+                                                                           
+                                                                     
+                                                                          
+                                                                           
+                                                                            
+                                                                             
+                                                                          
+                                                                        
+                                                                   
+                                                  
+  
+         
+                                                                          
+                                                                       
+                                                                            
+                                                                            
+                                                                         
+                                                                      
+                                                                         
+                                                                               
+                                                                              
+                                                                               
+                           
+  
+         
+                                                                             
+                                                                     
+                                                                             
+                                                                         
+                                                            
+  
+
+#endif // QF_PORT_HPP
+

--- a/ports/ucos-iii/qs_port.hpp
+++ b/ports/ucos-iii/qs_port.hpp
@@ -1,0 +1,61 @@
+/// @file
+/// @brief QS/C++ port to uC/OS-III and 32-bit CPUs
+/// @cond
+///***************************************************************************
+// Last updated for version 6.6.0
+// Last updated on  2019-10-14
+//
+//                    Q u a n t u m  L e a P s
+//                    ------------------------
+//                    Modern Embedded Software
+//
+// Copyright (C) 2005-2019 Quantum Leaps. All rights reserved.
+//
+// This program is open source software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Alternatively, this program may be distributed and modified under the
+// terms of Quantum Leaps commercial licenses, which expressly supersede
+// the GNU General Public License and are specifically designed for
+// licensees interested in retaining the proprietary status of their code.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <www.gnu.org/licenses>.
+//
+// Contact information:
+// <www.state-machine.com>
+// <info@state-machine.com>
+///***************************************************************************
+/// @endcond
+
+#ifndef QS_PORT_HPP
+#define QS_PORT_HPP
+
+#define QS_TIME_SIZE        4U
+#define QS_OBJ_PTR_SIZE     4U
+#define QS_FUN_PTR_SIZE     4U
+
+//****************************************************************************
+// NOTE: QS might be used with or without other QP components, in which case
+// the separate definitions of the macros QF_CRIT_STAT_TYPE, QF_CRIT_ENTRY,
+// and QF_CRIT_EXIT are needed. In this port QS is configured to be used with
+// the QF framework, by simply including "qf_port.hpp" *before* "qs.hpp".
+//
+#include "qf_port.hpp" // use QS with QF
+
+#if (CPU_CFG_CRITICAL_METHOD == CPU_CRITICAL_METHOD_STATUS_LOCAL)
+    #define QS_CRIT_STAT_    CPU_SR cpu_sr;
+    #define QS_CRIT_E_()     CPU_CRITICAL_ENTER()
+    #define QS_CRIT_X_()     CPU_CRITICAL_EXIT(); QS_REC_DONE()
+#endif // CPU_CFG_CRITICAL_METHOD
+
+#include "qs.hpp"      // QS platform-independent public interface
+
+#endif // QS_PORT_HPP


### PR DESCRIPTION
I have added a new port that supports UC-OS-III. 
### Changes

- Most of the `OS_CPU `macros in version 3 have changed to the prefix `CPU_ `instead.
- Data structures have been updated to API of version 3
- Conditional compilation of type of Queue for `QP::QActive`. This is due to the fact that UC-OS now has an internal queue per task which can be enabled/disabled via `OS_CFG_TASK_Q_EN `.
- `m_thread `is of type `OS_TCB*` since creating a task now needs a Task control block.
- Added an example based on the Arduino SDK

### How to test

I have added an example for the uc-os-iii port in `examples/ucos-iii/ArduinoDue-qpcpp-ucos-iii`. The example requires the Arduino SDK and a [UCOS-3 port for Arduino ](https://github.com/vChavezB/uc-os3-arduino-due) that I released some time ago. In addition, I [modified ](https://github.com/vChavezB/qp-arduino/tree/ucos3) the QP Arduino repository to make it compatible with the QP CPP uc-os-ii port.

The example creates a task that posts a signal periodically. This signal is consumed by a `QP::QActive` and prints through the serial port when it enters a new state and makes a transition. I think the uc-os-ii examples could be ported but version 3 but need refactoring due to the API change between v2 and v3. The example I provide can serve as a reference of what needs to be changed for UC-OS v3.